### PR TITLE
Adding new Container and Container.debian dockerfiles to enable rootl…

### DIFF
--- a/openvoxserver/Containerfile
+++ b/openvoxserver/Containerfile
@@ -127,11 +127,13 @@ RUN chown -R puppet /etc/puppetlabs/puppetserver && \
 
 USER puppet
 
-RUN mkdir -p /home/puppet/.puppetlabs/etc/ && \
-        ln -s /etc/puppetlabs/puppet/ /home/puppet/.puppetlabs/etc/puppet
+RUN mkdir -p /home/puppet/.puppetlabs && \
+        ln -s /etc/puppetlabs /home/puppet/.puppetlabs/etc && \
+        ln -s /opt/puppetlabs /home/puppet/.puppetlabs/opt
 
 #We need to tell puppet to use the default installation for the non-root user.
-RUN echo 'confdir = /etc/puppetlabs/puppet' >> /etc/puppetlabs/puppet/puppet.conf
+RUN echo 'confdir = /etc/puppetlabs/puppet' >> /etc/puppetlabs/puppet/puppet.conf && \
+	puppet config set cadir /etc/puppetlabs/puppetserver/ca/
 
 WORKDIR /home/puppet
 # k8s uses livenessProbe, startupProbe, readinessProbe and ignores HEALTHCHECK

--- a/openvoxserver/Containerfile
+++ b/openvoxserver/Containerfile
@@ -68,6 +68,7 @@ ENV OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m" \
     OPENVOXSERVER_ENABLE_ENV_CACHE_DEL_API=true \
     ENVIRONMENTPATH=/etc/puppetlabs/code/environments \
     HIERACONFIG='$confdir/hiera.yaml' \
+    HOME=/home/puppet \
     CSR_ATTRIBUTES='{}'
 
 COPY docker-entrypoint.sh \
@@ -128,42 +129,6 @@ USER puppet
 
 RUN mkdir -p /home/puppet/.puppetlabs/etc/ && \
         ln -s /etc/puppetlabs/puppet/ /home/puppet/.puppetlabs/etc/puppet
-
-ENV OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m" \
-    confdir=/etc/puppetlabs/puppet \
-    PATH=$PATH:/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin \
-    SSLDIR=/etc/puppetlabs/puppet/ssl \
-    LOGDIR=/var/log/puppetlabs/puppetserver \
-    OPENVOXSERVER_HOSTNAME="" \
-    CERTNAME="" \
-    DNS_ALT_NAMES="" \
-    OPENVOXSERVER_PORT=8140 \
-    AUTOSIGN=true \
-    OPENVOXSERVER_MAX_ACTIVE_INSTANCES=1 \
-    OPENVOXSERVER_MAX_REQUESTS_PER_INSTANCE=0 \
-    CA_ENABLED=true \
-    CA_TTL=157680000 \
-    CA_HOSTNAME=puppet \
-    CA_PORT=8140 \
-    CA_ALLOW_SUBJECT_ALT_NAMES=false \
-    INTERMEDIATE_CA=false \
-    INTERMEDIATE_CA_BUNDLE=/etc/puppetlabs/intermediate/ca.pem \
-    INTERMEDIATE_CRL_CHAIN=/etc/puppetlabs/intermediate/crl.pem \
-    INTERMEDIATE_CA_KEY=/etc/puppetlabs/intermediate/key.pem \
-    USE_OPENVOXDB=true \
-    OPENVOXDB_SERVER_URLS=https://openvoxdb:8081 \
-    OPENVOX_STORECONFIGS_BACKEND="puppetdb" \
-    OPENVOX_STORECONFIGS=true \
-    OPENVOX_REPORTS="puppetdb" \
-    OPENVOXSERVER_GRAPHITE_EXPORTER_ENABLED=false \
-    OPENVOXSERVER_GRAPHITE_PORT=9109 \
-    OPENVOXSERVER_GRAPHITE_HOST=exporter \
-    OPENVOXSERVER_ENVIRONMENT_TIMEOUT=unlimited \
-    OPENVOXSERVER_ENABLE_ENV_CACHE_DEL_API=true \
-    ENVIRONMENTPATH=/etc/puppetlabs/code/environments \
-    HIERACONFIG='$confdir/hiera.yaml' \
-    HOME=/home/puppet \
-    CSR_ATTRIBUTES='{}'
 
 #We need to tell puppet to use the default installation for the non-root user.
 RUN echo 'confdir = /etc/puppetlabs/puppet' >> /etc/puppetlabs/puppet/puppet.conf

--- a/openvoxserver/Containerfile.debian
+++ b/openvoxserver/Containerfile.debian
@@ -129,10 +129,12 @@ RUN chown -R puppet /etc/puppetlabs/puppetserver && \
 
 USER puppet
 
-RUN mkdir -p /home/puppet/.puppetlabs/etc/ && \
-        ln -s /etc/puppetlabs/puppet/ /home/puppet/.puppetlabs/etc/puppet
+RUN mkdir -p /home/puppet/.puppetlabs && \
+        ln -s /etc/puppetlabs /home/puppet/.puppetlabs/etc && \
+        ln -s /opt/puppetlabs /home/puppet/.puppetlabs/opt
 
-RUN echo 'confdir = /etc/puppetlabs/puppet' >> /etc/puppetlabs/puppet/puppet.conf
+RUN echo 'confdir = /etc/puppetlabs/puppet' >> /etc/puppetlabs/puppet/puppet.conf && \
+	puppet config set cadir /etc/puppetlabs/puppetserver/ca/
 WORKDIR /home/puppet
 
 # k8s uses livenessProbe, startupProbe, readinessProbe and ignores HEALTHCHECK

--- a/openvoxserver/Containerfile.debian
+++ b/openvoxserver/Containerfile.debian
@@ -70,6 +70,7 @@ ENV OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m" \
     OPENVOXSERVER_ENABLE_ENV_CACHE_DEL_API=true \
     ENVIRONMENTPATH=/etc/puppetlabs/code/environments \
     HIERACONFIG='$confdir/hiera.yaml' \
+    HOME=/home/puppet \
     CSR_ATTRIBUTES='{}'
 
 COPY docker-entrypoint.sh \
@@ -102,7 +103,6 @@ RUN groupadd -g ${OPENVOX_USER_GID} puppet && \
     cp -pr /etc/puppetlabs/puppet /var/tmp && \
     cp -pr /opt/puppetlabs/server/data/puppetserver /var/tmp && \
     rm -rf /var/tmp/puppet/ssl
-#    apt-get install -y openvox-agent=${OPENVOXAGENT_VERSION}-1+debian${DEBIAN_VERSION} && \
 
 # needs to be copied after package installation
 COPY puppetserver /etc/default/puppetserver
@@ -131,42 +131,6 @@ USER puppet
 
 RUN mkdir -p /home/puppet/.puppetlabs/etc/ && \
         ln -s /etc/puppetlabs/puppet/ /home/puppet/.puppetlabs/etc/puppet
-
-ENV OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m" \
-    confdir=/etc/puppetlabs/puppet \
-    PATH=$PATH:/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin \
-    SSLDIR=/etc/puppetlabs/puppet/ssl \
-    LOGDIR=/var/log/puppetlabs/puppetserver \
-    OPENVOXSERVER_HOSTNAME="" \
-    CERTNAME="" \
-    DNS_ALT_NAMES="" \
-    OPENVOXSERVER_PORT=8140 \
-    AUTOSIGN=true \
-    OPENVOXSERVER_MAX_ACTIVE_INSTANCES=1 \
-    OPENVOXSERVER_MAX_REQUESTS_PER_INSTANCE=0 \
-    CA_ENABLED=true \
-    CA_TTL=157680000 \
-    CA_HOSTNAME=puppet \
-    CA_PORT=8140 \
-    CA_ALLOW_SUBJECT_ALT_NAMES=false \
-    INTERMEDIATE_CA=false \
-    INTERMEDIATE_CA_BUNDLE=/etc/puppetlabs/intermediate/ca.pem \
-    INTERMEDIATE_CRL_CHAIN=/etc/puppetlabs/intermediate/crl.pem \
-    INTERMEDIATE_CA_KEY=/etc/puppetlabs/intermediate/key.pem \
-    USE_OPENVOXDB=true \
-    OPENVOXDB_SERVER_URLS=https://openvoxdb:8081 \
-    OPENVOX_STORECONFIGS_BACKEND="puppetdb" \
-    OPENVOX_STORECONFIGS=true \
-    OPENVOX_REPORTS="puppetdb" \
-    OPENVOXSERVER_GRAPHITE_EXPORTER_ENABLED=false \
-    OPENVOXSERVER_GRAPHITE_PORT=9109 \
-    OPENVOXSERVER_GRAPHITE_HOST=exporter \
-    OPENVOXSERVER_ENVIRONMENT_TIMEOUT=unlimited \
-    OPENVOXSERVER_ENABLE_ENV_CACHE_DEL_API=true \
-    ENVIRONMENTPATH=/etc/puppetlabs/code/environments \
-    HIERACONFIG='$confdir/hiera.yaml' \
-    HOME=/home/puppet \
-    CSR_ATTRIBUTES='{}'
 
 RUN echo 'confdir = /etc/puppetlabs/puppet' >> /etc/puppetlabs/puppet/puppet.conf
 WORKDIR /home/puppet

--- a/openvoxserver/Containerfile.debian
+++ b/openvoxserver/Containerfile.debian
@@ -1,4 +1,5 @@
 ARG UBUNTU_VERSION=24.04
+ARG DEBIAN_VERSION=12
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 
 ARG BUILD_PKGS="ruby3.2-dev gcc make cmake pkg-config libssl-dev libc6-dev libssh2-1-dev"
@@ -10,7 +11,7 @@ RUN apt-get update && \
     gem install --no-doc r10k -v $R10K_VERSION && \
     gem install --no-doc rugged -v $RUGGED_VERSION -- --with-ssh
 
-FROM ubuntu:${UBUNTU_VERSION} AS final
+FROM debian:${DEBIAN_VERSION} AS final
 
 ARG vcs_ref
 ARG build_type
@@ -24,6 +25,7 @@ ARG OPENVOXDB_VERSION=8.9.0
 ARG OPENVOX_USER_UID=999
 ARG OPENVOX_USER_GID=999
 ARG UBUNTU_VERSION=24.04
+ARG DEBIAN_VERSION=12
 
 LABEL org.label-schema.maintainer="Voxpupuli Team <voxpupuli@groups.io>" \
       org.label-schema.vendor="OpenVoxProject" \
@@ -79,11 +81,11 @@ COPY docker-entrypoint.d /docker-entrypoint.d
 COPY --from=builder /var/lib/gems/ /var/lib/gems/
 COPY --from=builder /usr/local/bin/r10k /usr/local/bin/
 
-ADD https://apt.overlookinfratech.com/openvox${OPENVOX_RELEASE}-release-ubuntu${UBUNTU_VERSION}.deb /
-RUN apt-get update && \
-    apt-get install -y ca-certificates && \
-    dpkg -i /openvox${OPENVOX_RELEASE}-release-ubuntu${UBUNTU_VERSION}.deb && \
-    rm /openvox${OPENVOX_RELEASE}-release-ubuntu${UBUNTU_VERSION}.deb
+#ADD https://apt.overlookinfratech.com/openvox${OPENVOX_RELEASE}-release-ubuntu${UBUNTU_VERSION}.deb /
+ADD https://apt.overlookinfratech.com/openvox${OPENVOX_RELEASE}-release-debian${DEBIAN_VERSION}.deb /
+RUN apt update && apt install -y ca-certificates && \
+	dpkg -i /openvox${OPENVOX_RELEASE}-release-debian${DEBIAN_VERSION}.deb && \
+	rm -f /openvox${OPENVOX_RELEASE}-release-debian${DEBIAN_VERSION}.deb
 
 RUN groupadd -g ${OPENVOX_USER_GID} puppet && \
     useradd -m -u ${OPENVOX_USER_UID} -g puppet puppet && \
@@ -91,15 +93,16 @@ RUN groupadd -g ${OPENVOX_USER_GID} puppet && \
     apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y $PACKAGES && \
-    apt-get install -y openvox-agent=${OPENVOXAGENT_VERSION}-1+ubuntu${UBUNTU_VERSION} && \
-    apt-get install -y openvox-server=${OPENVOXSERVER_VERSION}-1+ubuntu${UBUNTU_VERSION} && \
-    apt-get install -y openvoxdb-termini=${OPENVOXDB_VERSION}-1+ubuntu${UBUNTU_VERSION} && \
+    apt-get install -y openvox-agent=${OPENVOXAGENT_VERSION}-1+debian${DEBIAN_VERSION} && \
+    apt-get install -y openvox-server=${OPENVOXSERVER_VERSION}-1+debian${DEBIAN_VERSION} && \
+    apt-get install -y openvoxdb-termini=${OPENVOXDB_VERSION}-1+debian${DEBIAN_VERSION} && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     cp -pr /etc/puppetlabs/puppet /var/tmp && \
     cp -pr /opt/puppetlabs/server/data/puppetserver /var/tmp && \
     rm -rf /var/tmp/puppet/ssl
+#    apt-get install -y openvox-agent=${OPENVOXAGENT_VERSION}-1+debian${DEBIAN_VERSION} && \
 
 # needs to be copied after package installation
 COPY puppetserver /etc/default/puppetserver
@@ -165,10 +168,9 @@ ENV OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m" \
     HOME=/home/puppet \
     CSR_ATTRIBUTES='{}'
 
-#We need to tell puppet to use the default installation for the non-root user.
 RUN echo 'confdir = /etc/puppetlabs/puppet' >> /etc/puppetlabs/puppet/puppet.conf
-
 WORKDIR /home/puppet
+
 # k8s uses livenessProbe, startupProbe, readinessProbe and ignores HEALTHCHECK
 HEALTHCHECK --interval=20s --timeout=15s --retries=12 --start-period=3m CMD ["/healthcheck.sh"]
 


### PR DESCRIPTION
This is a pull request to hopefully add a rootless container build option.  
https://github.com/OpenVoxProject/container-openvoxserver/issues/7


It might be wise to create three Containerfiles....
Containerfile - This one can be the original, rooted application.
Containerfile.debian - A debian deployment that runs as a non root user.
Container.ubuntu - An ubuntu deployment that runs as a non root user

The structure of the new Containerfiles is mostly unchanged, but with a few additions. And the deployment of the debian version versus ubuntu are also almost identical, except for using the debian repo into of the ubuntu repo.

**NOTE**
If someone is running a linux OS running FIPS mode, the Ubuntu container WILL NOT WORK.  Openssl on ubuntu 24.04 is completely broken for FIPS mode and you will get ALGO errors when the certs are generated.  The only method I found to solve this was to either add development or testing repos and install openssl 3.4, or compiling openssl by source.  This got messy and I decided to not go this route as the debian container seems to run.


Major Changes:
(Debian Only) - Added DEBIAN_VERSION ARG, so that one can systematically reference/change the build.  I.E:
`ADD https://apt.overlookinfratech.com/openvox${OPENVOX_RELEASE}-release-debian${DEBIAN_VERSION}.deb`

Major permission changes - Since we are no longer running as root, we need to make sure that ALL the files required can be accessed by the puppet user:
```
RUN chown -R puppet /etc/puppetlabs/puppetserver && \
        chown -R puppet:puppet /var/tmp/puppet && \
        chown -R puppet:puppet /opt/puppetlabs && \
        chown -R puppet:puppet /usr/local/bin && \
        chown -R puppet:puppet /var/lib/gems && \
        chown -R puppet:puppet /etc/puppetlabs && \
        chown -R puppet:puppet /var/tmp/puppetserver && \
        chown -R puppet:puppet /etc/default && \
        chown -R puppet:puppet /docker-entrypoint.sh /healthcheck.sh /docker-entrypoint.d
```
(note - this could be simplified a bit if desired)

SYMLINK for non-root user - Puppet is configured in such a way that a non-root user's confdir, ssl and other directories are interpolated via the users HOME folder.  This caused many issues in the build as the container was referencing paths such as:
`/home/puppet/.puppetlabs/etc/...`

I decided the easiest way to fix this was actually to just use a simple SYMLINK:
```
RUN mkdir -p /home/puppet/.puppetlabs/etc/ && \
        ln -s /etc/puppetlabs/puppet/ /home/puppet/.puppetlabs/etc/puppet
```
This solved almost all of those problems.  It allowed the same files to be referenced.  However the container was still referencing the locations as `/home/puppet/.puppetlabs/etc/`, So I made another change.  I simply added a `confdir` directive in the puppet.conf.  Since the puppet.conf located in `/etc/puppetlabs/puppet/puppet/conf` is the same file as `/home/puppet/.puppetlabs/etc/puppet/puppet.conf`, the change was read and handled nicely.

The container now seems to start correctly:
```
...
2025-01-31 16:11:20,106 INFO  [p.t.s.s.status-service] Registering status service HTTP API at /status
2025-01-31 16:11:20,120 INFO  [o.e.j.s.h.ContextHandler] Started o.e.j.s.ServletContextHandler@7433e438{/status,null,AVAILABLE}J                            2025-01-31 16:11:20,134 INFO  [p.s.a.analytics-service] Not checking for updates - opt-out setting exists
2025-01-31 16:11:20,134 INFO  [p.s.a.analytics-service] Puppet Server Update Service has successfully started and will run in the background
2025-01-31 16:11:20,134 INFO  [p.s.a.analytics-service] Not submitting module metrics via Dropsonde -- submission is disabled. Enable this feature by setting `dropsonde.enabled` to true in Puppet Server's config.i
2025-01-31 16:11:20,135 INFO  [p.s.c.certificate-authority-service] Starting CA servicet                                                                    2025-01-31 16:11:20,139 INFO  [p.s.m.master-service] Puppet Server has successfully started and is now ready to handle requests
```

Which I run via a podman run command:
```
podman run -itd --name openvox-server -e OPENVOXSERVER_HOSTNAME=openvox \
        --name openvox --hostname openvox registry-auth.podman-dev.core.gtri.org/openvoxserver:debian
```

LASTLY - This is running, but I dont have an easy way to test adding an agent to it currently, so some assistance with testing would be helpful!