### PR TITLE
Fix warning of deprecate use of cp -n

### DIFF
--- a/openvoxserver/docker-entrypoint.d/20-use-templates-initially.sh
+++ b/openvoxserver/docker-entrypoint.d/20-use-templates-initially.sh
@@ -10,7 +10,7 @@ TEMPLATES=/var/tmp/puppet
 cd /etc/puppetlabs/puppet
 for f in auth.conf hiera.yaml puppet.conf puppetdb.conf
 do
-    test -f "$TEMPLATES/$f" && cp -n --update=none "$TEMPLATES/$f" .
+    test -f "$TEMPLATES/$f" && cp -p --update=none "$TEMPLATES/$f" .
 done
 cd /
 

--- a/openvoxserver/docker-entrypoint.d/20-use-templates-initially.sh
+++ b/openvoxserver/docker-entrypoint.d/20-use-templates-initially.sh
@@ -10,7 +10,7 @@ TEMPLATES=/var/tmp/puppet
 cd /etc/puppetlabs/puppet
 for f in auth.conf hiera.yaml puppet.conf puppetdb.conf
 do
-    test -f "$TEMPLATES/$f" && cp -np "$TEMPLATES/$f" .
+    test -f "$TEMPLATES/$f" && cp -n --update=none "$TEMPLATES/$f" .
 done
 cd /
 


### PR DESCRIPTION
https://github.com/OpenVoxProject/container-openvoxserver/blob/8834bb42f037cb7d6f58d32c02708f601c4097b8/openvoxserver/docker-entrypoint.d/20-use-templates-initially.sh#L13

reports into log:
penvox_puppet.1.dikrnt7sb9k7@ds01    | cp: warning: behavior of -n is non-portable and may change in future; use --update=none instead