### PR TITLE
remove `set -e` causing failures when configmaps mounted

### DIFF
--- a/openvoxserver/container-entrypoint.d/30-set-permissions.sh
+++ b/openvoxserver/container-entrypoint.d/30-set-permissions.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 chown -R puppet:puppet /etc/puppetlabs/puppet/
 chown -R puppet:puppet /opt/puppetlabs/server/data/puppetserver/
 chown -R puppet:puppet /etc/puppetlabs/puppetserver/


### PR DESCRIPTION
Hi 
Please find a PR related to issue https://github.com/OpenVoxProject/container-openvoxserver/issues/75
Regards

John