### PR TITLE
Update 84-metrics.conf.tmpl

### DIFF
--- a/openvoxserver/container-entrypoint.d/84-metrics.conf.tmpl
+++ b/openvoxserver/container-entrypoint.d/84-metrics.conf.tmpl
@@ -2,7 +2,7 @@
 metrics: {
     # a server id that will be used as part of the namespace for metrics produced
     # by this server
-    server-id: localhost
+    server-id: ${HOSTNAME}
     registries: {
         puppetserver: {
             # specify metrics to allow in addition to those in the default list


### PR DESCRIPTION
Add environment variable for server-id, when running multiple instances of puppet_server it is quite an issue to identify which compiler is which when they are all identifying as localhost