### PR TITLE
fix: missing curl when not CA

### DIFF
--- a/openvoxserver/Containerfile.alpine
+++ b/openvoxserver/Containerfile.alpine
@@ -3,7 +3,7 @@ FROM alpine:3.22 AS base
 # Install JDK
 ARG JDK_VERSION=17
 RUN apk update && apk upgrade \
-    && apk add --no-cache openjdk${JDK_VERSION}-jre-headless bash
+    && apk add --no-cache openjdk${JDK_VERSION}-jre-headless bash curl
 
 ################################################################################
 


### PR DESCRIPTION
Hi, 

when container is running with CA service it will try to check if the CA is running via the helper function `ca_running` inside `[90-ca.sh](https://github.com/OpenVoxProject/container-openvoxserver/blob/main/openvoxserver/container-entrypoint.d/90-ca.sh)`, but it requires curl to do so. So when trying to build a container that does not have the CA service enabled it will fail.

Example output:

```
openvox  | Running /container-entrypoint.d/90-ca.sh
openvox  | turning off CA
openvox  | /container-entrypoint.d/90-ca.sh: line 6: curl: command not found
openvox  | /container-entrypoint.d/90-ca.sh: line 6: curl: command not found
openvox  | /container-entrypoint.d/90-ca.sh: line 6: curl: command not found
```