### PR TITLE
fix: cp: replace deprecated -n option

### DIFF
--- a/openvoxserver/docker-entrypoint.d/20-use-templates-initially.sh
+++ b/openvoxserver/docker-entrypoint.d/20-use-templates-initially.sh
@@ -10,7 +10,7 @@ TEMPLATES=/var/tmp/puppet
 cd /etc/puppetlabs/puppet
 for f in auth.conf hiera.yaml puppet.conf puppetdb.conf
 do
-    test -f "$TEMPLATES/$f" && cp -np "$TEMPLATES/$f" .
+    test -f "$TEMPLATES/$f" && cp -p --update=none "$TEMPLATES/$f" .
 done
 cd /
 


### PR DESCRIPTION
  remove the warning message "behavior of -n is non-portable and may
  change in future; use --update=none instead"