### PR TITLE
fix: Confdir chown

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ services:
 
 #### Rootless Podman
 
-When using rootless Podman, the OpenVox Server process starts as a virtual `root` and then drops privileges to the `puppet` user.
+When using rootless Podman, the OpenVox Server process runs directly as the non-root `puppet` user (UID 1001) with the root group (GID 0).
 This can lead to permission issues with bind mount volumes, which you may want to use for the OpenVox SSL and CA directories. For example:
 
 ```shell

--- a/openvoxserver/prep_release_container.sh
+++ b/openvoxserver/prep_release_container.sh
@@ -82,8 +82,8 @@ else
 fi
 
 chown -R puppet:puppet /etc/puppetlabs/code
-chown -R puppet:puppet /etc/puppetlabs/puppet/ssl
-chown -R puppet:puppet /etc/puppetlabs/puppetserver/ca
+chown -R puppet:puppet /etc/puppetlabs/puppet
+chown -R puppet:puppet /etc/puppetlabs/puppetserver
 chown -R puppet:puppet /opt/puppetlabs/server/data/puppetserver
 chown -R puppet:puppet /var/log/puppetlabs/puppetserver
 chown -R puppet:puppet /var/run/puppetlabs/puppetserver


### PR DESCRIPTION
### Short description
Chown the `puppet` and `puppetserver` config directories. Should, ideally, fix #149.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
