### PR TITLE
fix: revert to uid/gid 999

### DIFF
--- a/Containerfile.alpine
+++ b/Containerfile.alpine
@@ -35,8 +35,8 @@ ARG RUBYGEM_R10K=5.0.3
 # renovate: datasource=rubygems depName=rugged
 ARG RUBYGEM_RUGGED=1.9.0
 
-ARG OPENVOX_USER_UID=1001
-ARG OPENVOX_USER_GID=1001
+ARG OPENVOX_USER_UID=999
+ARG OPENVOX_USER_GID=999
 
 # renovate: datasource=custom.voxpupuli-artifacts depName=openvox-server
 ARG OPENVOXSERVER_VERSION=8.14.0

--- a/Containerfile.ubuntu
+++ b/Containerfile.ubuntu
@@ -44,8 +44,8 @@ ARG RUBYGEM_R10K=5.0.3
 # renovate: datasource=rubygems depName=rugged
 ARG RUBYGEM_RUGGED=1.9.0
 
-ARG OPENVOX_USER_UID=1001
-ARG OPENVOX_USER_GID=1001
+ARG OPENVOX_USER_UID=999
+ARG OPENVOX_USER_GID=999
 
 # renovate: datasource=custom.voxpupuli-artifacts depName=openvox-server
 ARG OPENVOXSERVER_VERSION=8.14.0

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
     - [Permissions](#permissions)
       - [Rootless Podman](#rootless-podman)
       - [Docker](#docker)
+    - [UID/GID](#uidgid)
   - [How to deploy OpenVox/Puppet code](#how-to-deploy-openvoxpuppet-code)
     - [✅ Preferred way to deploy your code](#-preferred-way-to-deploy-your-code)
     - [🔥 Not recommended way, but often used, pattern from the non-container world](#-not-recommended-way-but-often-used-pattern-from-the-non-container-world)
@@ -206,6 +207,18 @@ Permissions are managed for you, and from there the volume can be migrated using
 #### Docker
 
 Docker always runs rootfull, and does not need permissions adjustments.
+
+### UID/GID
+
+The image creates the `puppet` user with UID 999 and a corresponding group with GID 999 by default.
+These IDs determine file ownership inside the image and can be changed at build time.
+
+The container is configured with `USER puppet:0`, so the server process uses the `puppet` user's UID and group 0 at runtime.
+Directories required by the server are group-owned by group 0 and grant the group the same permissions as the owner.
+This also supports platforms such as OpenShift that run containers with an arbitrary UID in group 0.
+
+The build arguments only affect newly built images. They cannot be set as environment variables when starting an existing image.
+When changing the default IDs, ensure that bind mounts and existing volumes have compatible ownership and permissions.
 
 ## How to deploy OpenVox/Puppet code
 

--- a/openvoxserver/prep_release_container.sh
+++ b/openvoxserver/prep_release_container.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 
 set -e
+source /etc/os-release
 
-if command -v apk > /dev/null 2>&1; then
+if [ "$ID" = "alpine" ]; then
+  if [ "$OPENVOX_USER_GID" -eq 999 ]; then
+    OPENVOX_GROUP=ping
+  else
+    OPENVOX_GROUP=puppet
+  fi
+else
+  OPENVOX_GROUP=puppet
+fi
+
+if [ "$ID" = "alpine" ]; then
   apk update
   apk add --no-cache \
     alpine-sdk \
@@ -22,7 +33,7 @@ if command -v apk > /dev/null 2>&1; then
     ruby \
     ruby-dev \
     runuser
-elif command -v apt-get > /dev/null 2>&1; then
+elif [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
   apt-get update
   apt-get install -y --no-install-recommends \
     build-essential \
@@ -56,7 +67,7 @@ gem install --no-document rugged:${RUBYGEM_RUGGED} -- --with-ssh
 gem install --no-document racc:1.8.1
 gem install --no-document syslog:0.4.0
 
-if command -v apk > /dev/null 2>&1; then
+if [ "$ID" = "alpine" ]; then
   apk del --purge alpine-sdk
 else
   apt-get purge -y build-essential
@@ -67,13 +78,16 @@ fi
 
 # Create puppet user and group, and set permissions on necessary directories
 # Used for rootless execution of the container and to match permissions expected by Puppet Server
-if command -v addgroup > /dev/null 2>&1 && command -v apk > /dev/null 2>&1; then
-  addgroup -g "${OPENVOX_USER_GID}" puppet
-  adduser -G puppet -u "${OPENVOX_USER_UID}" -h /opt/puppetlabs/server/data/puppetserver -H -D -s /sbin/nologin puppet
+if [ "$ID" = "alpine" ]; then
+  if [ "$OPENVOX_USER_GID" != 999 ]; then
+    addgroup -g "${OPENVOX_USER_GID}" "${OPENVOX_GROUP}"
+  fi
+
+  adduser -G "${OPENVOX_GROUP}" -u "${OPENVOX_USER_UID}" -h /opt/puppetlabs/server/data/puppetserver -H -D -s /sbin/nologin puppet
 else
-  groupadd --gid "${OPENVOX_USER_GID}" puppet
+  groupadd --gid "${OPENVOX_USER_GID}" "${OPENVOX_GROUP}"
   useradd \
-    --gid puppet \
+    --gid "${OPENVOX_USER_GID}" \
     --home-dir /opt/puppetlabs/server/data/puppetserver \
     --no-create-home \
     --shell /usr/sbin/nologin \
@@ -81,12 +95,12 @@ else
     puppet
 fi
 
-chown -R puppet:puppet /etc/puppetlabs/code
-chown -R puppet:puppet /etc/puppetlabs/puppet/ssl
-chown -R puppet:puppet /etc/puppetlabs/puppetserver/ca
-chown -R puppet:puppet /opt/puppetlabs/server/data/puppetserver
-chown -R puppet:puppet /var/log/puppetlabs/puppetserver
-chown -R puppet:puppet /var/run/puppetlabs/puppetserver
+chown -R puppet:"${OPENVOX_GROUP}" /etc/puppetlabs/code
+chown -R puppet:"${OPENVOX_GROUP}" /etc/puppetlabs/puppet/ssl
+chown -R puppet:"${OPENVOX_GROUP}" /etc/puppetlabs/puppetserver/ca
+chown -R puppet:"${OPENVOX_GROUP}" /opt/puppetlabs/server/data/puppetserver
+chown -R puppet:"${OPENVOX_GROUP}" /var/log/puppetlabs/puppetserver
+chown -R puppet:"${OPENVOX_GROUP}" /var/run/puppetlabs/puppetserver
 
 chmod 0700 /opt/puppetlabs/server/data/puppetserver/jars
 chmod 0700 /opt/puppetlabs/server/data/puppetserver/yaml


### PR DESCRIPTION
fixes #150

This might be breaking for all users who have used the newer images after #131 . We have mistakenly switched the uid/gid to 1001 and are now reverting it back to 999.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [X] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
