### PR TITLE
fix: keep puppetserver gems out of the var-dir mount path

### DIFF
--- a/openvoxserver/files/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf
+++ b/openvoxserver/files/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf
@@ -34,7 +34,18 @@ jruby-puppet: {
 
     # (optional) path to puppet var dir; if not specified, will use
     # /opt/puppetlabs/server/data/puppetserver
-    master-var-dir: /opt/puppetlabs/server/data/puppetserver
+    #
+    # NOTE: intentionally pointed at a dedicated sub-directory instead of the
+    # package default /opt/puppetlabs/server/data/puppetserver. That default
+    # mixes variable runtime data (yaml, server_data, bucket, reports) with
+    # static, image-provided content that must NOT be overlaid by a volume:
+    # the jruby-gems / vendored-jruby-gems directories (where `require 'puppet'`
+    # is loaded from). Keeping the var dir separate lets a persistent volume be
+    # mounted on /opt/puppetlabs/server/data/puppetserver/var without clobbering
+    # the gems, and makes a read-only root filesystem viable. The gem-home /
+    # gem-path settings above are deliberately absolute (not derived from this
+    # var dir) for the same reason.
+    master-var-dir: /opt/puppetlabs/server/data/puppetserver/var
 
     # (optional) path to puppet run dir; if not specified, will use
     # /var/run/puppetlabs/puppetserver

--- a/openvoxserver/prep_build_container.sh
+++ b/openvoxserver/prep_build_container.sh
@@ -23,6 +23,7 @@ install -d "/opt/puppetlabs/server/data" -m 0775
 install -d "/opt/puppetlabs/server/data/puppetserver" -m 0770
 install -d "/opt/puppetlabs/server/data/puppetserver/jars" -m 0700
 install -d "/opt/puppetlabs/server/data/puppetserver/jruby-gems" -m 0755
+install -d "/opt/puppetlabs/server/data/puppetserver/var" -m 0770
 install -d "/opt/puppetlabs/server/data/puppetserver/yaml" -m 0700
 install -d "/var/log/puppetlabs/puppetserver" -m 0700
 install -d "/var/run/puppetlabs/puppetserver" -m 0755


### PR DESCRIPTION
# AI Summarize of this PR

## Problem

The bundled `puppetserver.conf` points `master-var-dir` at `/opt/puppetlabs/server/data/puppetserver` -- the same directory that holds the static, image-provided `jruby-gems` and `vendored-jruby-gems` (where `require 'puppet'` is loaded from).

To persist variable runtime data (yaml, server_data, bucket, reports) people mount a volume on `data/puppetserver`. That overlays and empties the gem directories, so the server can no longer load Puppet and dies with:

```
LoadError: no such file to load -- puppet
```

The entrypoint only restores `vendored-jruby-gems`, not `jruby-gems`, so that workaround is incomplete.

## Fix

Point `master-var-dir` at a dedicated `.../puppetserver/var` sub-directory. The variable data now has its own mountable location, and the gems stay untouched at their absolute paths. `gem-home` / `gem-path` are already absolute and are not derived from the var-dir, so they are unaffected.

- `openvoxserver/files/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf`: `master-var-dir` -> `.../puppetserver/var`
- `openvoxserver/prep_build_container.sh`: create the new `var` directory (ownership is already handled by the recursive `chown` on `data/puppetserver`)

Applies to both the Ubuntu and Alpine images via the shared prep scripts.

## Verification

Built the Ubuntu image and ran, as the `puppet` user:

| Mount | `require 'puppet'` |
| --- | --- |
| none (baseline) | OK (8.27.0) |
| empty volume on `.../puppetserver/var` | OK (8.27.0) |
| empty volume on `.../puppetserver` | LoadError: no such file to load -- puppet |

So the new var dir is freely mountable without clobbering the gems, and the old foot-gun is reproduced as the control. This also makes running with a read-only root filesystem viable.

## Breaking change

This changes the default `master-var-dir` location. Existing deployments that persist or mount variable data at `/opt/puppetlabs/server/data/puppetserver` will need to move that mount to `/opt/puppetlabs/server/data/puppetserver/var`. Data previously persisted at the old path will not be picked up automatically.

## Follow-up

The Helm chart most likely needs a matching change. It currently mounts a volume over the whole `data/puppetserver` directory, which is exactly what triggers the `LoadError` and what this PR makes unnecessary. That mount should be moved to `.../puppetserver/var` (or dropped in favour of persisting only what actually needs it). Happy to follow up there.
