### PR TITLE
Create CDS Archive for JVM app class pre-loading

### DIFF
--- a/Containerfile.alpine
+++ b/Containerfile.alpine
@@ -109,7 +109,7 @@ USER puppet:0
 # Create a CDS archive in a stage for faster class loading.
 FROM app AS cds
 RUN OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m -XX:ArchiveClassesAtExit=/opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa" \
-    timeout 60 dumb-init /container-entrypoint.sh foreground || true
+    timeout --preserve-status 60 dumb-init /container-entrypoint.sh foreground || [ $? -eq 143 ]
 
 FROM app AS final
 COPY --from=cds /opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa /opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa

--- a/Containerfile.alpine
+++ b/Containerfile.alpine
@@ -22,7 +22,7 @@ COPY openvoxserver/prep_build_container.sh /
 RUN /prep_build_container.sh
 
 ################################################################################
-FROM base AS final
+FROM base AS app
 
 # renovate: datasource=rubygems depName=hiera-eyaml
 ARG RUBYGEM_HIERA_EYAML=5.0.1
@@ -79,7 +79,7 @@ ENV AUTOSIGN=true \
     OPENVOXSERVER_GRAPHITE_HOST=exporter \
     OPENVOXSERVER_GRAPHITE_PORT=9109 \
     OPENVOXSERVER_HOSTNAME="" \
-    OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m" \
+    OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m -XX:SharedArchiveFile=/opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa" \
     OPENVOXSERVER_MAX_ACTIVE_INSTANCES=1 \
     OPENVOXSERVER_MAX_REQUESTS_PER_INSTANCE=0 \
     OPENVOXSERVER_PORT=8140 \
@@ -105,6 +105,14 @@ COPY Containerfile.alpine /Containerfile
 RUN /prep_release_container.sh
 
 USER puppet:0
+
+# Create a CDS archive in a stage for faster class loading.
+FROM app AS cds
+RUN OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m -XX:ArchiveClassesAtExit=/opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa" \
+    timeout 60 dumb-init /container-entrypoint.sh foreground || true
+
+FROM app AS final
+COPY --from=cds /opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa /opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa
 
 # k8s uses livenessProbe, startupProbe, readinessProbe and ignores HEALTHCHECK
 HEALTHCHECK --interval=20s --timeout=15s --retries=12 --start-period=3m CMD ["/healthcheck.sh"]

--- a/Containerfile.alpine
+++ b/Containerfile.alpine
@@ -108,7 +108,7 @@ USER puppet:0
 
 # Create a CDS archive in a stage for faster class loading.
 FROM app AS cds
-RUN OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m -XX:ArchiveClassesAtExit=/opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa" \
+RUN OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m -XX:ArchiveClassesAtExit=/opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa -Xlog:cds=off" \
     timeout --preserve-status 60 dumb-init /container-entrypoint.sh foreground || [ $? -eq 143 ]
 
 FROM app AS final

--- a/Containerfile.ubuntu
+++ b/Containerfile.ubuntu
@@ -31,7 +31,7 @@ COPY openvoxserver/prep_build_container.sh /
 RUN /prep_build_container.sh
 
 ################################################################################
-FROM base AS final
+FROM base AS app
 
 # renovate: datasource=rubygems depName=hiera-eyaml
 ARG RUBYGEM_HIERA_EYAML=5.0.1
@@ -88,7 +88,7 @@ ENV AUTOSIGN=true \
     OPENVOXSERVER_GRAPHITE_HOST=exporter \
     OPENVOXSERVER_GRAPHITE_PORT=9109 \
     OPENVOXSERVER_HOSTNAME="" \
-    OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m" \
+    OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m -XX:SharedArchiveFile=/opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa" \
     OPENVOXSERVER_MAX_ACTIVE_INSTANCES=1 \
     OPENVOXSERVER_MAX_REQUESTS_PER_INSTANCE=0 \
     OPENVOXSERVER_PORT=8140 \
@@ -114,6 +114,14 @@ COPY Containerfile.ubuntu /Containerfile
 RUN /prep_release_container.sh
 
 USER puppet:0
+
+# Create a CDS archive in a stage for faster class loading.
+FROM app AS cds
+RUN OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m -XX:ArchiveClassesAtExit=/opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa" \
+    timeout 60 dumb-init /container-entrypoint.sh foreground || true
+
+FROM app AS final
+COPY --from=cds /opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa /opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa
 
 # k8s uses livenessProbe, startupProbe, readinessProbe and ignores HEALTHCHECK
 HEALTHCHECK --interval=20s --timeout=15s --retries=12 --start-period=3m CMD ["/healthcheck.sh"]

--- a/Containerfile.ubuntu
+++ b/Containerfile.ubuntu
@@ -118,7 +118,7 @@ USER puppet:0
 # Create a CDS archive in a stage for faster class loading.
 FROM app AS cds
 RUN OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m -XX:ArchiveClassesAtExit=/opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa" \
-    timeout 60 dumb-init /container-entrypoint.sh foreground || true
+    timeout --preserve-status 60 dumb-init /container-entrypoint.sh foreground || [ $? -eq 143 ]
 
 FROM app AS final
 COPY --from=cds /opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa /opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa

--- a/Containerfile.ubuntu
+++ b/Containerfile.ubuntu
@@ -117,7 +117,7 @@ USER puppet:0
 
 # Create a CDS archive in a stage for faster class loading.
 FROM app AS cds
-RUN OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m -XX:ArchiveClassesAtExit=/opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa" \
+RUN OPENVOXSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m -XX:ArchiveClassesAtExit=/opt/puppetlabs/server/apps/puppetserver/puppetserver.jsa -Xlog:cds=off" \
     timeout --preserve-status 60 dumb-init /container-entrypoint.sh foreground || [ $? -eq 143 ]
 
 FROM app AS final

--- a/openvoxserver/files/container-entrypoint.sh
+++ b/openvoxserver/files/container-entrypoint.sh
@@ -87,17 +87,20 @@ post_execution_handler() {
 
 ## Sigterm Handler
 # shellcheck disable=SC2317 # function is called when the container receives a SIGTERM signal
+# We're forwarding the sigterm to the child JVM process (/usr/bin/java) instead of the
+# wrapper script (/opt/puppetlabs/server/apps/puppetserver/cli/apps/foreground), else it
+# doesn't shut down gracefully.
 sigterm_handler() {
   echoerr "Catching SIGTERM"
   if [ $pid -ne 0 ]; then
-    echoerr "sigterm_handler for PID '${pid}' triggered"
+    echoerr "sigterm_handler triggered, shutting down service"
     # the above if statement is important because it ensures
     # that the application has already started. without it you
     # could attempt cleanup steps if the application failed to
     # start, causing errors.
     run_custom_handler sigterm-handler
-    kill -15 "$pid"
-    wait "$pid"
+    pkill -TERM -f puppet-server-release.jar
+    while pgrep -f puppet-server-release.jar > /dev/null; do sleep 1; done
     post_execution_handler
   fi
   exit 143; # 128 + 15 -- SIGTERM


### PR DESCRIPTION
### Short description
It's possible to memory-map the JVM application classes (ie jruby, clojure, puppetserver, etc) instead of unpacking them from the jar files on startup. The base classes are already shipped with whatever JRE you run. Doing this for the application itself shaves ~10% of startup time in my testing (at the cost of ~100MB space). This uses an extra stage during the containerfile build steps.

See: https://docs.oracle.com/en/java/javase/21/vm/class-data-sharing.html

The hard part, and what made this take so long to work out, was figuring out why the SIGTERM handler wasn't cleanly shutting down the JVM. It was nothing to do with `dumb-init` behavior, and nothing to do with the Alpine container's busybox version of `pkill`. No, we only need to target the child process, not the puppetserver wrapper that calls `runuser`. And as an added bonus the shutdown seems to be faster as well. :)

Part of #139

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
