### PR TITLE
fix: make puppetdb_query function available in built images

### DIFF
--- a/openvoxserver/prep_release_container.sh
+++ b/openvoxserver/prep_release_container.sh
@@ -123,6 +123,16 @@ done
 puppetserver gem install --no-document openvox:${RUBYGEM_OPENVOX}
 puppetserver gem install --no-document hiera-eyaml:${RUBYGEM_HIERA_EYAML}
 
+# Colocate the puppetdb termini with the openvox gem lib so the puppetdb_query
+# function resolves during compilation. The termini in vendor_ruby (on
+# ruby-load-path) cover the require-loaded terminus and report processor, but
+# Puppet 4 functions load via the Pops system loader, rooted at puppet's own lib
+# rather than ruby-load-path. Since #141 gem-installs openvox instead of using
+# the OS packages (whose openvoxdb-termini colocated everything in vendor_ruby),
+# that root is the gem lib, so puppetdb_query would otherwise be unknown.
+cp -r /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet \
+  "/opt/puppetlabs/server/data/puppetserver/jruby-gems/gems/openvox-${RUBYGEM_OPENVOX}/lib/"
+
 # Expose the `eyaml` CLI. hiera-eyaml lives only in the JRuby gem-home, and its
 # binstub there resolves the gem against the default (distro) gem-path, where it
 # is no longer installed, so it can't simply be symlinked. Wrap it to run under


### PR DESCRIPTION
### Short description

Fixes #159: `puppetdb_query` fails with `Unknown function: 'puppetdb_query'` during catalog compilation in built images, even though the PuppetDB termini are installed.

The termini are installed in `vendor_ruby` (on `ruby-load-path`), which covers the `require`-loaded indirector terminus and report processor — so storeconfigs and reports work. But Puppet 4 functions load via the Pops **system loader**, which is rooted at puppet's own lib dir, not `ruby-load-path`. Since #141 the images gem-install `openvox` instead of installing the OS packages (whose `openvoxdb-termini` deb colocated the termini with the vendored puppet in `vendor_ruby`), so that root is now the gem's lib dir and the termini's `puppet/functions/` is off the search path.

This colocates the termini `puppet/` tree with the openvox gem lib, restoring the layout the OS packages relied on. The filenames don't collide with openvox's own.

See #159 for the full analysis and an alternative (shipping the termini as a module on `basemodulepath`).

> AI use: this patch was developed with the assistance of Claude (Claude Code).

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a `Signed-off-by` annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added an attribution trailer to each AI-assisted commit
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
