### PR TITLE
Bundle the vendored modules

### DIFF
--- a/Containerfile.alpine
+++ b/Containerfile.alpine
@@ -18,6 +18,38 @@ ARG OPENVOXDB_VERSION=8.14.1
 ADD https://artifacts.voxpupuli.org/openvox-server/${OPENVOXSERVER_VERSION}/openvox-server-${OPENVOXSERVER_VERSION}.tar.gz /
 ADD https://artifacts.voxpupuli.org/openvoxdb/${OPENVOXDB_VERSION}/openvoxdb-${OPENVOXDB_VERSION}.tar.gz /
 
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-augeas_core
+ARG MODULE_AUGEAS_CORE=1.5.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-cron_core
+ARG MODULE_CRON_CORE=1.3.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-host_core
+ARG MODULE_HOST_CORE=1.3.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-mount_core
+ARG MODULE_MOUNT_CORE=1.3.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-scheduled_task
+ARG MODULE_SCHEDULED_TASK=3.2.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-selinux_core
+ARG MODULE_SELINUX_CORE=1.4.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-sshkeys_core
+ARG MODULE_SSHKEYS_CORE=2.5.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-yumrepo_core
+ARG MODULE_YUMREPO_CORE=2.1.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-zfs_core
+ARG MODULE_ZFS_CORE=1.6.1
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-zone_core
+ARG MODULE_ZONE_CORE=1.2.0
+
+ADD https://github.com/OpenVoxProject/puppetlabs-augeas_core/archive/refs/tags/v${MODULE_AUGEAS_CORE}.tar.gz /vendor_modules/puppetlabs-augeas_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-cron_core/archive/refs/tags/v${MODULE_CRON_CORE}.tar.gz /vendor_modules/puppetlabs-cron_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-host_core/archive/refs/tags/v${MODULE_HOST_CORE}.tar.gz /vendor_modules/puppetlabs-host_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-mount_core/archive/refs/tags/v${MODULE_MOUNT_CORE}.tar.gz /vendor_modules/puppetlabs-mount_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-scheduled_task/archive/refs/tags/v${MODULE_SCHEDULED_TASK}.tar.gz /vendor_modules/puppetlabs-scheduled_task.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-selinux_core/archive/refs/tags/v${MODULE_SELINUX_CORE}.tar.gz /vendor_modules/puppetlabs-selinux_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-sshkeys_core/archive/refs/tags/v${MODULE_SSHKEYS_CORE}.tar.gz /vendor_modules/puppetlabs-sshkeys_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-yumrepo_core/archive/refs/tags/v${MODULE_YUMREPO_CORE}.tar.gz /vendor_modules/puppetlabs-yumrepo_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-zfs_core/archive/refs/tags/v${MODULE_ZFS_CORE}.tar.gz /vendor_modules/puppetlabs-zfs_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-zone_core/archive/refs/tags/v${MODULE_ZONE_CORE}.tar.gz /vendor_modules/puppetlabs-zone_core.tar.gz
+
 COPY openvoxserver/prep_build_container.sh /
 RUN /prep_build_container.sh
 

--- a/Containerfile.ubuntu
+++ b/Containerfile.ubuntu
@@ -27,6 +27,38 @@ ARG OPENVOXDB_VERSION=8.14.1
 ADD https://artifacts.voxpupuli.org/openvox-server/${OPENVOXSERVER_VERSION}/openvox-server-${OPENVOXSERVER_VERSION}.tar.gz /
 ADD https://artifacts.voxpupuli.org/openvoxdb/${OPENVOXDB_VERSION}/openvoxdb-${OPENVOXDB_VERSION}.tar.gz /
 
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-augeas_core
+ARG MODULE_AUGEAS_CORE=1.5.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-cron_core
+ARG MODULE_CRON_CORE=1.3.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-host_core
+ARG MODULE_HOST_CORE=1.3.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-mount_core
+ARG MODULE_MOUNT_CORE=1.3.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-scheduled_task
+ARG MODULE_SCHEDULED_TASK=3.2.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-selinux_core
+ARG MODULE_SELINUX_CORE=1.4.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-sshkeys_core
+ARG MODULE_SSHKEYS_CORE=2.5.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-yumrepo_core
+ARG MODULE_YUMREPO_CORE=2.1.0
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-zfs_core
+ARG MODULE_ZFS_CORE=1.6.1
+# renovate: datasource=github-tags depName=OpenVoxProject/puppetlabs-zone_core
+ARG MODULE_ZONE_CORE=1.2.0
+
+ADD https://github.com/OpenVoxProject/puppetlabs-augeas_core/archive/refs/tags/v${MODULE_AUGEAS_CORE}.tar.gz /vendor_modules/puppetlabs-augeas_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-cron_core/archive/refs/tags/v${MODULE_CRON_CORE}.tar.gz /vendor_modules/puppetlabs-cron_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-host_core/archive/refs/tags/v${MODULE_HOST_CORE}.tar.gz /vendor_modules/puppetlabs-host_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-mount_core/archive/refs/tags/v${MODULE_MOUNT_CORE}.tar.gz /vendor_modules/puppetlabs-mount_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-scheduled_task/archive/refs/tags/v${MODULE_SCHEDULED_TASK}.tar.gz /vendor_modules/puppetlabs-scheduled_task.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-selinux_core/archive/refs/tags/v${MODULE_SELINUX_CORE}.tar.gz /vendor_modules/puppetlabs-selinux_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-sshkeys_core/archive/refs/tags/v${MODULE_SSHKEYS_CORE}.tar.gz /vendor_modules/puppetlabs-sshkeys_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-yumrepo_core/archive/refs/tags/v${MODULE_YUMREPO_CORE}.tar.gz /vendor_modules/puppetlabs-yumrepo_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-zfs_core/archive/refs/tags/v${MODULE_ZFS_CORE}.tar.gz /vendor_modules/puppetlabs-zfs_core.tar.gz
+ADD https://github.com/OpenVoxProject/puppetlabs-zone_core/archive/refs/tags/v${MODULE_ZONE_CORE}.tar.gz /vendor_modules/puppetlabs-zone_core.tar.gz
+
 COPY openvoxserver/prep_build_container.sh /
 RUN /prep_build_container.sh
 

--- a/openvoxserver/prep_build_container.sh
+++ b/openvoxserver/prep_build_container.sh
@@ -66,6 +66,6 @@ cp -r puppet "$RUBY_LIB_DIR/"
 mkdir -p /opt/puppetlabs/puppet/vendor_modules
 cd /vendor_modules
 for module in augeas_core cron_core host_core mount_core scheduled_task selinux_core sshkeys_core yumrepo_core zfs_core zone_core; do
-  tar -x -z -f puppetlabs-$module.tar.gz
-  mv puppetlabs-$module-* /opt/puppetlabs/puppet/vendor_modules/$module
+  mkdir /opt/puppetlabs/puppet/vendor_modules/$module
+  tar -xzf puppetlabs-$module.tar.gz -C /opt/puppetlabs/puppet/vendor_modules/$module --strip-components 1
 done

--- a/openvoxserver/prep_build_container.sh
+++ b/openvoxserver/prep_build_container.sh
@@ -62,3 +62,10 @@ cd /puppetdb-${OPENVOXDB_VERSION}
 RUBY_LIB_DIR="/opt/puppetlabs/puppet/lib/ruby/vendor_ruby"
 install -d "$RUBY_LIB_DIR"
 cp -r puppet "$RUBY_LIB_DIR/"
+
+mkdir -p /opt/puppetlabs/puppet/vendor_modules
+cd /vendor_modules
+for module in augeas_core cron_core host_core mount_core scheduled_task selinux_core sshkeys_core yumrepo_core zfs_core zone_core; do
+  tar -x -z -f puppetlabs-$module.tar.gz
+  mv puppetlabs-$module-* /opt/puppetlabs/puppet/vendor_modules/$module
+done

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,17 @@
     },
     {
       "customType": "regex",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^v(?<version>\\d+\\.\\d+\\.\\d+)$",
+      "managerFilePatterns": [
+        "/(^|/)Containerfile\\.(?:alpine|ubuntu)$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=github-tags\\s+depName=(?<depName>OpenVoxProject/puppetlabs-[a-z0-9_]+)\\s*\\n\\s*ARG\\s+MODULE_[A-Z0-9_]+=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ]
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": [
         "/(^|/)Containerfile\\.(?:alpine|ubuntu)$/",
         "/(^|/)build_versions\\.yaml$/"


### PR DESCRIPTION
### Short description
Because we've started including the agent dependency as a gem instead of a package we need to ship the core modules separately. After ten million hours in regex101 I do believe this should be handled via renovate from here on out.
Fixes #163 

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
