### PR TITLE
Add a basic catalog for CI to compile as a smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,13 @@ jobs:
             RUBYGEM_R10K=${{ matrix.rubygem_r10k }}
             RUBYGEM_RUGGED=${{ matrix.rubygem_rugged }}
             JDK_VERSION=${{ matrix.jdk_version }}
+      - name: Test catalog
+        run: |
+          docker run --rm -v "$PWD/tests:/tests:ro,Z" --entrypoint puppet \
+            ci/openvoxserver:${{ matrix.server_version }}-${{ matrix.os }}-${{ matrix.platform }} \
+            catalog compile --manifest /tests/simple_catalog.pp --render-as json > catalog.json
+          grep -q '"type":"Host"' catalog.json
+          grep -q '"type":"Cron"' catalog.json
 
   tests:
     needs:

--- a/tests/simple_catalog.pp
+++ b/tests/simple_catalog.pp
@@ -1,0 +1,14 @@
+# Example catalog for CI testing
+
+host { 'test.example.com':
+  ensure => present,
+  ip     => '10.0.0.1',
+}
+
+cron { 'nightly-job':
+  ensure  => present,
+  command => '/bin/true',
+  user    => 'root',
+  hour    => '2',
+  minute  => '0',
+}


### PR DESCRIPTION
### Short description
Prevents #163 from reoccurring

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
