### PR TITLE
chown /run/openvox so ownership matches other runtime dirs

### DIFF
--- a/openvoxserver/prep_release_container.sh
+++ b/openvoxserver/prep_release_container.sh
@@ -168,6 +168,7 @@ for d in /etc/puppetlabs /var/log/puppetlabs /var/run/puppetlabs /opt/puppetlabs
   chmod -R g=u "$d"
   find "$d" -type d -exec chmod g+s {} +
 done
+chown puppet /run/openvox
 
 # the foreground starting script has this check before running the server:
 # [ "$EUID" = "$(id -u ${USER})" ]


### PR DESCRIPTION
### Short description
After the containerfile unification there was a report of the following:
```
Entrypoint PID 7
Running /container-entrypoint.d/20-use-templates-initially.sh
/usr/local/share/openvox/config_lib.sh: line 14: /run/openvox/config-lib-cache: Permission denied
sed: can't read /run/openvox/config-lib-cache: No such file or directory
/container-entrypoint.d/20-use-templates-initially.sh: line 12: cd: null directory
```
The intent is that the `gid` runs as 0, but containerd (and by extension k8s) looks like it ignores the `0` in `USER puppet:0`. You can test this out by execing `id` in your container orchestration platform of choice. Point is, this only impacted `/run/openvox` because it's not created prior to the loop above (else I could just add it to the prior `chown` list).


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
