### PR TITLE
Update readme and migration notes regarding puppet uid and gid

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,8 +3,9 @@
 ## V8.12.0 -> V8.13.0
 
 UID is changed from 1001 on alpine and 999 on ubuntu to 64604.
-If you already deployed the containers with mounted volume, you NEED to change the ownershop of these volumes and the files underneath.
+If you already deployed the containers with mounted volumes, you HAVE to change the ownership of these volumes and the files underneath.
 
 ```bash
-chown -R 64604:64604 [PATH TO THE VOLUME]
+chown -R 64604:0 /path/to/ca_mountpoint
+chown -R 64604:0 /path/to/ssl_mountpoint
 ```

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ services:
 
 #### Rootless Podman
 
-When using rootless Podman, the OpenVox Server process runs directly as the non-root `puppet` user (UID 1001) with the root group (GID 0).
+When using rootless Podman, the OpenVox Server process runs directly as the non-root `puppet` user (UID 64604) with the root group (GID 0).
 This can lead to permission issues with bind mount volumes, which you may want to use for the OpenVox SSL and CA directories. For example:
 
 ```shell


### PR DESCRIPTION
### Short description

The puppet user UID has changed to 64604 since v8.13.0.

However, the migration notes were incorrect regarding the GID, leading to issues with the CA service (Fixes #192 ). 
The README was also still referencing the old UID.

### Checklist

I have:

- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
